### PR TITLE
Rename links

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@ I changed the `foo()` function so that ...
 
 Here are some things to check before creating the pull request. If you encounter any issues, don't hesitate to ask for help :)
 
-- [ ] I have read the [contributor's guide](https://github.com/arnab39/reptrix/blob/main/CONTRIBUTING.md).
+- [ ] I have read the [contributor's guide](https://github.com/BARL-SSL/reptrix/blob/main/CONTRIBUTING.md).
 - [ ] The base branch of my pull request is the `dev` branch, not the `main` branch.
-- [ ] I ran the [code checks](https://github.com/arnab39/reptrix/blob/main/CONTRIBUTING.md#implement-your-changes) on the files I added or modified and fixed the errors.
-- [ ] I updated the [changelog](https://github.com/arnab39/reptrix/blob/main/CHANGELOG.md).
+- [ ] I ran the [code checks](https://github.com/BARL-SSL/reptrix/blob/main/CONTRIBUTING.md#implement-your-changes) on the files I added or modified and fixed the errors.
+- [ ] I updated the [changelog](https://github.com/BARL-SSL/reptrix/blob/main/CHANGELOG.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Changed
+- Rename all instances of https://github.com/arnab39/reptrix to https://github.com/BARL-SSL/reptrix
 
 ### Removed
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -307,5 +307,5 @@ on [PyPI], the following steps can be used to release a new version for
 [tox]: https://tox.readthedocs.io/en/stable/
 [virtual environment]: https://realpython.com/python-virtual-environments-a-primer/
 [virtualenv]: https://virtualenv.pypa.io/en/stable/s
-[repository]: https://github.com/arnab39/reptrix
-[issue tracker]: https://github.com/arnab39/reptrix/issues
+[repository]: https://github.com/BARL-SSL/reptrix
+[issue tracker]: https://github.com/BARL-SSL/reptrix/issues

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 <p align="center">
     <br>
-    <img src="https://github.com/arnab39/reptrix/assets/6922389/06e6bffb-adac-460b-81b4-b1078859b563" alt="Reptrix" width="200"/>
+    <img src="https://github.com/BARL-SSL/reptrix/assets/6922389/06e6bffb-adac-460b-81b4-b1078859b563" alt="Reptrix" width="200"/>
     <br>
 <p>
 
@@ -117,7 +117,7 @@ You can install the latest version of reptrix using:
 
 You can clone this repository and manually install it with:
 
-```pip install git+https://github.com/arnab39/reptrix```
+```pip install git+https://github.com/BARL-SSL/reptrix```
 
 ### Setup Conda environment for examples
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,11 +12,11 @@ license = MIT
 license_files = LICENSE.txt
 long_description = file: README.md
 long_description_content_type = text/markdown; charset=UTF-8; variant=GFM
-url = https://github.com/arnab39/reptrix/
+url = https://github.com/BARL-SSL/reptrix/
 # Add here related links, for example:
 project_urls =
-    Tracker = https://github.com/arnab39/reptrix/issues
-    Source = https://github.com/arnab39/reptrix/
+    Tracker = https://github.com/BARL-SSL/reptrix/issues
+    Source = https://github.com/BARL-SSL/reptrix/
 
 # Change if running only on Windows, Mac or Linux (comma-separated)
 platforms = any


### PR DESCRIPTION
# Description

The aim is to replace links to reflect move to org from personal GitHub.

# Proposed Changes

I changed all instances of https://github.com/arnab39/reptrix to https://github.com/BARL-SSL/reptrix


# Checklist

Here are some things to check before creating the pull request. If you encounter any issues, don't hesitate to ask for help :)

- [x] I have read the [contributor's guide](https://github.com/arnab39/reptrix/blob/main/CONTRIBUTING.md).
- [x] The base branch of my pull request is the `dev` branch, not the `main` branch.
- [x] I ran the [code checks](https://github.com/arnab39/reptrix/blob/main/CONTRIBUTING.md#implement-your-changes) on the files I added or modified and fixed the errors.
- [x] I updated the [changelog](https://github.com/arnab39/reptrix/blob/main/CHANGELOG.md).
